### PR TITLE
Added CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @davidwhitney @alefranz

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,4 @@ There will inevitably be a series of changes that do not modify the standard - s
 
 ## Questions
 
-Contact David Whitney or Alession Franceschelli
+Contact David Whitney or Alessio Franceschelli.


### PR DESCRIPTION
Should we add a CODEOWNERS?

This is to define who needs to approve the PRs, setting it up to only us for now while we get to a more refined version of the docs.
So, it would require approval to at least one of us to merge a PR (we could setup auto-merge as well).
We will also get automatic review requests every time a new PR is raised (excluding drafts)
