### PR TITLE
Make it easier to find the response code guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ There's repeated confusion around the terms "API" and "Endpoint" when we're talk
 
 The following categories describe our requirements for API design. **It is expected you follow the approach outlined in each sub-section**.
 
-- [Urls, Verbs, and Response Codes](standards/UrlsVerbsAndResponseCodes.md)
+- [Urls, Verbs](standards/UrlsAndVerbs.md)
 - [Versioning](standards/Versioning.md)
 - [Security](standards/Security.md)
 - [PCI Data](standards/PCIData.md)

--- a/index.mjs
+++ b/index.mjs
@@ -6,7 +6,7 @@ var mdDocs = [
     "reference/MaturityModel.md",
     "reference/DesignPrinciples.md",
     "reference/RestConstraints.md",
-    "standards/UrlsVerbsAndResponseCodes.md",
+    "standards/UrlsAndVerbs.md",
     "standards/Versioning.md",
     "standards/Security.md",
     "standards/MandatoryEndpoints.md",

--- a/standards/UrlsAndVerbs.md
+++ b/standards/UrlsAndVerbs.md
@@ -1,4 +1,4 @@
-# URLs, Verbs, and Response Codes
+# URLs and Verbs
 
 ---
 
@@ -111,6 +111,8 @@ The available verbs are listed in the RFC 261 specification in section 9.1.2.
 Operations MUST use the proper HTTP methods whenever possible, and operation idempotency MUST be respected.
 
 Borrowed from [Microsoft REST API fundamentals](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#74-supported-methods), the following should be respected:
+
+For response/status codes see: [guidelines/StatusCodes.md](../guidelines/StatusCodes.md)
 
 Method  | Description                                                                                                                | Is Idempotent
 ------- | -------------------------------------------------------------------------------------------------------------------------- | -------------


### PR DESCRIPTION
Standards was a bit dead-end for that. Renamed and cross linked to match actual location of guidance. One of the devs was unable to find the status codes page because they got stuck in the dead-end of the urls page which incorrectly had response codes in the name but didn't point to the other page.

Changes:

* Rename & re-title urls page to not mention response codes (that it doesn't include)
* Add pointer from url guidance to status code page

If you want to see the result you can click around the updated mardkowns here:

* https://github.com/timabell-newday/API-Design/blob/response-code-links/README.md#api-standards
* https://github.com/timabell-newday/API-Design/blob/response-code-links/standards/UrlsAndVerbs.md#http-verbs-and-methods