### PR TITLE
Added a common data types guidelines page

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ These are a set of recommendations for solving common problems in API design. We
 - [Errors: ProblemDetails](guidelines/ProblemDetails.md)
 - [Collections and Pagination](guidelines/Collections.md)
 - [Naming](guidelines/Naming.md)
+- [Common Data Types](guidelines/CommonDataTypes.md)
 - [New API Checklist](guidelines/NewAPIChecklist.md)
 
 ## Documentation Guidelines

--- a/guidelines/CommonDataTypes.md
+++ b/guidelines/CommonDataTypes.md
@@ -1,0 +1,32 @@
+# Common Data Type Guidelines
+
+For data types that repeat across many APIs we want a consistent approach to represent the data to avoid any misinterpretation of the data and/or conversion errors.
+
+### Money
+
+* Services **MUST** include the 3 letter [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) currency code when field(s) representing a monetary amount are present.
+* Services **SHOULD** use a single currency code field when multiple monetary fields are present and the currency is the same for all of the fields. 
+* Services **MUST NOT** represent the amount as minor unit where the currency has a major and minor unit. For example, £12.34 should be represented as 12.34, not 1234.
+* Services **SHOULD** represent the amount as a number, to avoid string parsing and to allow the deserialisers to deserialise directly into the native representation (e.g. decimal in .NET).
+
+Examples
+
+    {
+	    ...,
+	    "paymentCard": "1234567890123456",
+	    "amount": {
+            "currency": "GBP",
+            "value": 123.45
+        }
+    }
+
+    {
+	    ...,
+	    "balance": 1234.33,
+	    "requestedPayment": 10,
+	    "recommendedPayment": 100,
+	    "interestAccrued": 12.88,
+	    "currency": "GBP"
+    }
+
+---

--- a/guidelines/CommonDataTypes.md
+++ b/guidelines/CommonDataTypes.md
@@ -10,23 +10,24 @@ For data types that repeat across many APIs we want a consistent approach to rep
 * Services **SHOULD** represent the amount as a number, to avoid string parsing and to allow the deserialisers to deserialise directly into the native representation (e.g. decimal in .NET).
 
 Examples
-
-    {
-	    ...,
-	    "paymentCard": "1234567890123456",
-	    "amount": {
-            "currency": "GBP",
-            "value": 123.45
-        }
+```json
+{
+    "paymentCard": "1234567890123456",
+    "amount": {
+        "currency": "GBP",
+        "value": 123.45
     }
+}
+```
 
-    {
-	    ...,
-	    "balance": 1234.33,
-	    "requestedPayment": 10,
-	    "recommendedPayment": 100,
-	    "interestAccrued": 12.88,
-	    "currency": "GBP"
-    }
+```json
+{
+    "balance": 1234.33,
+    "requestedPayment": 10,
+    "recommendedPayment": 100,
+    "interestAccrued": 12.88,
+    "currency": "GBP"
+}
+```
 
 ---

--- a/guidelines/CommonDataTypes.md
+++ b/guidelines/CommonDataTypes.md
@@ -1,6 +1,6 @@
 # Common Data Type Guidelines
 
-For data types that repeat across many APIs we want a consistent approach to represent the data to avoid any misinterpretation of the data and/or conversion errors.
+For data types that repeat across many APIs we want a consistent approach to represent the data to avoid any misinterpretation of the data or conversion errors.
 
 ### Money
 


### PR DESCRIPTION
Added a common data types guidelines page, with some guidelines for representing money, based on discussions with some of the mobile developers and @alefranz. Come thoughts:

- I'm not sure "Common data types" is the correct description for the page.
- We initially thought of recommending a nested type with fields currency and value but when we thought about some of our APIs that return many money fields it would be quite messy, especially as all the fields are the same currency. So we thought the guideline should rather be about how to represent money on a model that about a specific new data type.
- Should we add guidelines on naming the currency code field and the amount field?
