### PR TITLE
Update codeowners to be the principal github team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @davidwhitney @alefranz
+*       @NewDayTechnology/principals


### PR DESCRIPTION
### Description of Update
Change the code owners from individuals to the [Principals  GitHub Team](https://github.com/orgs/NewDayTechnology/teams/principals/members)

### Value
- Centralises repository admin privileges instead of having individuals added
