### PR TITLE
Fix link to CONTRIBUTING.md in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ Please read the [Documentation Guidelines](guidelines/Documentation.md) to under
 
 ## Contributing
 
-See the [contributing guidelines](CONTRIBUTING.md).
+See the [contributing guidelines](.github/CONTRIBUTING.md).
 
 [A list of authors and contributors is avilable here](AUTHORS.md).


### PR DESCRIPTION
# Description of the Change

#27 moved CONTRIBUTING.md from root to .github/, but the link to that file in README.md wasn't updated.

## Value

The link in readme is no longer broken.

## Applicable Issues

N/A
